### PR TITLE
Fix 'Can not find module JSZip' errors when bundling

### DIFF
--- a/app/js/slicer.js
+++ b/app/js/slicer.js
@@ -1,7 +1,7 @@
 'use strict';
 
 let fs = require('filesaver.js');
-let JSZip = require('JSZip');
+let JSZip = require('jszip');
 
 let viewport = require('./viewport.js');
 let printer = require('./printer.js');


### PR DESCRIPTION
Replaced "JSZip" with "jszip" in `app/js/slicer.js`.
Fixes the following error that is risen on `npm start`:

```
Cannot find module 'JSZip' from '~/hackathon-slicer/app/js'
```
